### PR TITLE
Remove peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,5 @@
     "run-sequence": "^1.1.4",
     "should": "^7.1.1",
     "through2": "^2.0.0"
-  },
-  "peerDependencies": {
-    "deku": "^0.5.6",
-    "redux": "^3.0.4",
-    "virtual-element": "^1.2.0"
   }
 }


### PR DESCRIPTION
After #2, there will be no more need for a peerDependency on `virtual-element`.

`redux` and `deku` are already assumed to be used by the user, there should be no need to add a peerDependency to them. Also, if the user really wishes so, he can use something else other than `deku`.

Their versions should at least be set to `*` or `>=`. Alternatively, you can get rid of them altogether, like so.
